### PR TITLE
Fix typo in TAxis.cxx

### DIFF
--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -543,7 +543,7 @@ void TAxis::GetCenter(Double_t *center) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return an array with the lod edge of all bins
+/// Return an array with the low edge of all bins
 
 void TAxis::GetLowEdge(Double_t *edge) const
 {


### PR DESCRIPTION
`"Return an array with the *lod* edge of all bins" -> "Return an array with the *low* edge of all bins"`